### PR TITLE
Add Client, Message, and User models

### DIFF
--- a/backend/app/Models/Client.php
+++ b/backend/app/Models/Client.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'address',
+        'cnpj',
+        'active',
+    ];
+}

--- a/backend/app/Models/Message.php
+++ b/backend/app/Models/Message.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id',
+        'user_id',
+        'content',
+        'caption',
+        'status',
+        'type',
+        'message_id',
+        'reference_message_id',
+        'direction',
+        'file_url',
+        'file_name',
+        'file_type',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -20,6 +20,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'client_id',
+        'role',
     ];
 
     /**

--- a/backend/database/migrations/2024_09_14_042332_create_clients_table.php
+++ b/backend/database/migrations/2024_09_14_042332_create_clients_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+            $table->string('cnpj')->unique();
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/backend/database/migrations/2024_09_14_042833_add_client_id_and_role_to_users_table.php
+++ b/backend/database/migrations/2024_09_14_042833_add_client_id_and_role_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('client_id')->after('id');
+            $table->string('role')->default('user')->after('password');
+
+            $table->foreign('client_id')->references('id')->on('clients');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['client_id']);
+            $table->dropColumn('client_id');
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/backend/database/migrations/2024_09_14_043642_create_messages_table.php
+++ b/backend/database/migrations/2024_09_14_043642_create_messages_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('content');
+            $table->string('caption');
+            $table->string('status');
+            $table->string('type');
+            $table->string('message_id')->unique();
+            $table->string('reference_message_id')->nullable();
+            $table->string('direction');
+            $table->string('file_url')->nullable();
+            $table->string('file_name')->nullable();
+            $table->string('file_type')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('messages', function (Blueprint $table) {
+            $table->foreign('reference_message_id')->references('message_id')->on('messages');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/backend/database/migrations/2024_09_14_050412_create_services_table.php
+++ b/backend/database/migrations/2024_09_14_050412_create_services_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('services', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained()->onDelete('cascade'); 
+            $table->string('name'); 
+            $table->text('description')->nullable(); 
+            $table->decimal('price', 10, 2);           
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('services');
+    }
+};

--- a/backend/database/migrations/2024_09_14_050727_create_products_table.php
+++ b/backend/database/migrations/2024_09_14_050727_create_products_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained()->onDelete('cascade'); 
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('image')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->integer('stock')->default(0);
+            $table->enum('status', ['available', 'out_of_stock'])->default('available');
+            $table->timestamps(); 
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+}
+

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -2,6 +2,6 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+// Route::get('/', function () {
+//     return view('welcome');
+// });


### PR DESCRIPTION
This commit adds the Client, Message, and User models to the application. These models are used to represent clients, messages, and users respectively. The Client model has fields for name, email, phone, address, CNPJ, and active status. The Message model has fields for client_id, user_id, content, caption, status, type, message_id, reference_message_id, direction, file_url, file_name, and file_type. The User model has fields for name, email, password, client_id, and role.

Co-authored-by: Yuri Machado